### PR TITLE
Instruction extract to logical units

### DIFF
--- a/Project2/PipelineSimulation.Core/CPU.cs
+++ b/Project2/PipelineSimulation.Core/CPU.cs
@@ -13,13 +13,12 @@ namespace PipelineSimulation.Core
         public int CurrentClockCycle = 0;
         private int _currentBuffer = 0;
 
-		public byte[] Memory { get; set; } = new byte[1048576]; //1 MiB = 1024 KiB = 1024 * 1024 B
+		//public byte[] Memory { get; set; } = new byte[1048576]; //1 MiB = 1024 KiB = 1024 * 1024 B
+        public Memory Memory = Memory.GetInstance();
 
-		public Reader Rd;
+        public Reader Rd;
 
         private Dictionary<ushort, Register> _registers = new Dictionary<ushort, Register>();
-
-		public Dictionary<ushort, Instruction> _operations = new Dictionary<ushort, Instruction>();
 
         public SortedDictionary<int, CPUBuffer> Buffers = new SortedDictionary<int, CPUBuffer>();
 
@@ -44,12 +43,6 @@ namespace PipelineSimulation.Core
                 {
 					var reg = (Register)Activator.CreateInstance(type);
 					_registers.Add(reg.ID, reg);
-                }
-
-				if (type.BaseType == typeof(Instruction))
-                {
-					var instruction = (Instruction)Activator.CreateInstance(type, this);
-					_operations.Add(instruction.OpCode, instruction);
                 }
 
                 if (type.BaseType == typeof(CPUBuffer))

--- a/Project2/PipelineSimulation.Core/Functional Units/ALU.cs
+++ b/Project2/PipelineSimulation.Core/Functional Units/ALU.cs
@@ -1,13 +1,27 @@
-﻿using System;
+﻿using PipelineSimulation.Core.Instructions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace PipelineSimulation.Core.Functional_Units {
-	class ALU : FunctionalUnit {
+	class ALU : FunctionalUnit
+	{
+		public ALU()
+        {
+			foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
+			{
+				if (type.BaseType == typeof(Instruction))
+				{
+					var instruction = (Instruction)Activator.CreateInstance(type, this);
+					if (instruction.OpCode > 0x05 && instruction.OpCode < 0x0A) //this should be all of our integer ADD and SUB instructions
+						_operations.Add(instruction.OpCode, instruction);
+				}
+			}
+		}
 
-		//TODO: idk if we even need anything in here
-
-	}
+				
+}
 }

--- a/Project2/PipelineSimulation.Core/Functional Units/ELU.cs
+++ b/Project2/PipelineSimulation.Core/Functional Units/ELU.cs
@@ -1,13 +1,25 @@
-﻿using System;
+﻿using PipelineSimulation.Core.Instructions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace PipelineSimulation.Core.Functional_Units {
-	class ELU : FunctionalUnit {
-
-		//TODO: idk if we even need anything in here
-
+	class ELU : FunctionalUnit
+	{
+		public ELU()
+		{
+			foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
+			{
+				if (type.BaseType == typeof(Instruction))
+				{
+					var instruction = (Instruction)Activator.CreateInstance(type, this);
+					if (instruction.OpCode == 0x00) //only has NOP right now, still need to add other execution logic related instructions
+						_operations.Add(instruction.OpCode, instruction);
+				}
+			}
+		}
 	}
 }

--- a/Project2/PipelineSimulation.Core/Functional Units/FPU.cs
+++ b/Project2/PipelineSimulation.Core/Functional Units/FPU.cs
@@ -1,13 +1,28 @@
-﻿using System;
+﻿using PipelineSimulation.Core.Instructions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace PipelineSimulation.Core.Functional_Units {
-	public class FPU : FunctionalUnit {
-		
+	public class FPU : FunctionalUnit
+	{
 		//TODO: Registers and secial FPU functs
 
+
+		public FPU()
+		{
+			foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
+			{
+				if (type.BaseType == typeof(Instruction))
+				{
+					var instruction = (Instruction)Activator.CreateInstance(type, this);
+					if (instruction.OpCode > 0x0F && instruction.OpCode < 0x1E) //this should include ALL floating point instructions
+						_operations.Add(instruction.OpCode, instruction);
+				}
+			}
+		}
 	}
 }

--- a/Project2/PipelineSimulation.Core/Functional Units/FunctionalUnit.cs
+++ b/Project2/PipelineSimulation.Core/Functional Units/FunctionalUnit.cs
@@ -13,6 +13,8 @@ namespace PipelineSimulation.Core.Functional_Units {
 
 		// List of instructions belonging to the functional unit
 		public List<Instruction> Instructions;
+		//used a dictionary since thats what we used previously, but left the list here in case you all had different plans
+		public Dictionary<ushort, Instruction> _operations = new Dictionary<ushort, Instruction>();
 
 		// Currently running instruction
 		public Instruction CurrentlyRunning;


### PR DESCRIPTION
Completely pulled instruction dictionary from CPU class in favor of adding them to each respective logical unit
Started adding instructions to their respective logical unit based on OpCode (is this the best way?)

Wasn't too sure about where to put some of the instructions, so I didn't include everything. Please look over this before you merge it for sure. Of course, we can always make changes later if needed.